### PR TITLE
Fix extraneous f-string and organize imports

### DIFF
--- a/generate_pre_sprint_analysis.py
+++ b/generate_pre_sprint_analysis.py
@@ -122,7 +122,7 @@ def main():
 
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     with open(args.output, "w") as f:
-        f.write(f"# Pre-Sprint Analysis\n\n")
+        f.write("# Pre-Sprint Analysis\n\n")
         f.write(f"_Generated on {now}_\n\n")
         f.write("## Ticket Backlog\n\n")
         f.write(format_tickets(tickets) + "\n\n")


### PR DESCRIPTION
## Summary
- clean up `generate_pre_sprint_analysis.py`
- organize imports using `ruff --fix`
- remove superfluous `f` prefix from constant string

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68630aaf16388331a6bcfe693af21cac