### PR TITLE
Implement sprint simulation core

### DIFF
--- a/daily_work_simulator.py
+++ b/daily_work_simulator.py
@@ -10,5 +10,34 @@ class DailyWorkSimulator:
         :param team_member: TeamMember instance.
         :param assigned_tickets: List of Ticket instances.
         :param day: Day index or date.
+        :return: List of log strings for the day.
         """
-        raise NotImplementedError
+
+        logs = []
+        logs.append(f"Day {day} | {team_member.name} | Planning and standup")
+
+        for ticket in assigned_tickets:
+            if not team_member.can_handle_ticket(ticket):
+                logs.append(
+                    f"Day {day} | {team_member.name} | Unable to work on {ticket.ticket_id}"
+                )
+                continue
+
+            logs.append(
+                f"Day {day} | {team_member.name} | Started {ticket.ticket_id}: {ticket.description}"
+            )
+
+            ticket.status = "In Progress"
+            ticket.assigned_to = team_member.name
+            effort = team_member.estimate_effort(ticket)
+            ticket.actual_effort = effort
+            ticket.status = "Closed"
+            team_member.current_workload += effort
+            team_member.completed_tickets.append(ticket.ticket_id)
+
+            logs.append(
+                f"Day {day} | {team_member.name} | Completed {ticket.ticket_id} in {effort} pts"
+            )
+
+        logs.append(f"Day {day} | {team_member.name} | Wrap up and documentation")
+        return logs

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,28 @@
+import unittest
+from team_members import TeamMember
+from ticket_system import Ticket
+from sprint_simulator import SprintSimulator
+
+class TestSprintSimulation(unittest.TestCase):
+    def test_basic_run(self):
+        team = [
+            TeamMember(name="dev", role="Developer", skill_level=8, specialties=["Email", "Slack"]),
+            TeamMember(name="junior", role="Junior", skill_level=5, specialties=["Email"]),
+        ]
+
+        tickets = [
+            Ticket(ticket_id="SNW-1", source="ServiceNow", priority="High", category="Email", description="Email issue", estimated_effort=3),
+            Ticket(ticket_id="SNW-2", source="ServiceNow", priority="Low", category="Slack", description="Slack request", estimated_effort=2),
+        ]
+
+        sim = SprintSimulator(team, sprint_length_days=1)
+        sim.sprint_backlog = tickets
+        logs = sim.run_complete_simulation()
+
+        self.assertEqual(len(sim.completed_work), 2)
+        for t in tickets:
+            self.assertEqual(t.status, "Closed")
+        self.assertTrue(len(logs) > 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement ticket capacity and effort estimation in `TeamMember`
- provide a basic daily work simulator
- implement sprint simulator with standups and daily work
- add a simple unit test demonstrating a short sprint

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_68630cac60e883319bd495a3fb71ec79