### PR TITLE
Improve ticket dependency handling and escalation

### DIFF
--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -22,3 +22,38 @@ def test_basic_run():
     for t in tickets:
         assert t.status == "Closed"
     assert len(logs) > 0
+
+
+def test_dependency_blocking_and_unblocking():
+    team = [
+        TeamMember(name="senior", role="Senior", skill_level=8, specialties=["Email"]),
+    ]
+
+    t1 = Ticket(ticket_id="SNW-1", source="ServiceNow", priority="High", category="Email", description="First", estimated_effort=2)
+    t2 = Ticket(ticket_id="SNW-2", source="ServiceNow", priority="Low", category="Email", description="Second", estimated_effort=2, dependencies=["SNW-1"])
+
+    sim = SprintSimulator(team, sprint_length_days=2)
+    sim.sprint_backlog = [t1, t2]
+    sim.run_complete_simulation()
+
+    assert t1.status == "Closed"
+    assert t2.status == "Closed"
+    # Ensure the dependent ticket was blocked at least once
+    assert any("blocked" in log.lower() for log in sim.daily_logs)
+
+
+def test_escalation_flow():
+    team = [
+        TeamMember(name="junior", role="Junior", skill_level=4, specialties=["Email"]),
+        TeamMember(name="senior", role="Senior", skill_level=8, specialties=["Email"]),
+    ]
+
+    ticket = Ticket(ticket_id="SNW-3", source="ServiceNow", priority="High", category="Email", description="Hard issue", estimated_effort=6)
+
+    sim = SprintSimulator(team, sprint_length_days=1)
+    sim.sprint_backlog = [ticket]
+    sim.run_complete_simulation()
+
+    assert ticket.status == "Closed"
+    assert ticket.assigned_to == "senior"
+    assert any("Escalating" in log for log in sim.daily_logs)


### PR DESCRIPTION
## Summary
- block tickets with unresolved dependencies in `SprintSimulator.simulate_work_day`
- check dependencies and escalate large tasks in `DailyWorkSimulator`
- add tests for dependency blocking and escalation behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655824f304833198534ac30d6ab7ce