### PR TITLE
Improve metrics and expand ticket scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ pytest
 
 Further phases (sprint planning, daily simulation, retrospective) will be added following the specification in AGENTS.md.
 
+## Metrics Generation
+
+After running a simulation you can generate a structured metrics report:
+
+```python
+from ticket_system import TicketGenerator
+from sprint_simulator import SprintSimulator
+from team_members import TeamMember
+
+team = [TeamMember(name="dev", role="Developer", skill_level=8, specialties=["Email"])]
+tickets = TicketGenerator().generate_realistic_tickets(5)
+sim = SprintSimulator(team, sprint_length_days=1)
+sim.sprint_backlog = tickets
+sim.run_complete_simulation()
+metrics = sim.generate_metrics_report()
+sim.save_metrics_report("metrics.json")
+```
+
+This will save `metrics.json` containing velocity and completion statistics for the sprint.
+
 ## Specification
 
 Refer to `AGENTS.md` for the full project requirements and roadmap.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,16 @@
+from team_members import TeamMember
+from ticket_system import Ticket
+from sprint_simulator import SprintSimulator
+
+
+def test_metrics_generation():
+    team = [TeamMember(name="dev", role="Developer", skill_level=8, specialties=["Email"])]
+    ticket = Ticket(ticket_id="SNW-1", source="ServiceNow", priority="High", category="Email", description="Issue", estimated_effort=3)
+    sim = SprintSimulator(team, sprint_length_days=1)
+    sim.sprint_backlog = [ticket]
+    sim.run_complete_simulation()
+    metrics = sim.generate_metrics_report()
+
+    assert metrics["completed_tickets"] == 1
+    assert metrics["velocity"] > 0
+    assert metrics["utilization"]["dev"] > 0

--- a/ticket_system.py
+++ b/ticket_system.py
@@ -36,6 +36,8 @@ class TicketGenerator:
         {'category': 'MFA', 'description': 'Multi-factor authentication setup and troubleshooting'},
         {'category': 'File Sharing', 'description': 'File sharing permission escalations'},
         {'category': 'MDM', 'description': 'Mobile device management (MDM) enrollment issues'},
+        {'category': 'Access Management', 'description': 'User access reviews and permission updates'},
+        {'category': 'Security Patching', 'description': 'Operating system patching and reboot coordination'},
     ]
     INCIDENT_TEMPLATES = [
         {'category': 'Email', 'description': 'Email delivery failures and routing issues'},
@@ -45,6 +47,8 @@ class TicketGenerator:
         {'category': 'Network', 'description': 'Network connectivity issues affecting remote workers'},
         {'category': 'Security', 'description': 'Security incidents requiring immediate response'},
         {'category': 'Backup', 'description': 'Data backup and recovery operations'},
+        {'category': 'Database', 'description': 'Database outage or severe performance issue'},
+        {'category': 'AWS', 'description': 'AWS service disruption impacting production'},
     ]
     PROJECT_TEMPLATES = [
         {'category': 'Google Workspace', 'description': 'Implementation of new Google Workspace policies'},
@@ -54,6 +58,8 @@ class TicketGenerator:
         {'category': 'Infrastructure', 'description': 'Infrastructure upgrades and capacity planning'},
         {'category': 'Compliance', 'description': 'Compliance reporting and audit preparation'},
         {'category': 'Integration', 'description': 'Integration projects between enterprise tools'},
+        {'category': 'Containerization', 'description': 'Docker/Kubernetes environment improvements'},
+        {'category': 'Monitoring', 'description': 'Implementation of new monitoring dashboards'},
     ]
 
     # Distribution weights


### PR DESCRIPTION
## Summary
- add more ticket templates for operations, incidents and projects
- generate metrics at end of sprint simulation and expose helper to save them
- document metrics generation in README
- test metrics reporting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686948209c2c8331954ec18f8bdd72b1