### PR TITLE
Add triage meeting simulation

### DIFF
--- a/generate_pre_sprint_analysis.py
+++ b/generate_pre_sprint_analysis.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from ticket_system import TicketGenerator
 from team_members import TeamMember
+from sprint_planning import simulate_triage_meeting
 
 
 def build_team():
@@ -121,6 +122,8 @@ def main():
     team_size = len(team)
 
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    triage_notes, commitment = simulate_triage_meeting(tickets, team)
+
     with open(args.output, "w") as f:
         f.write("# Pre-Sprint Analysis\n\n")
         f.write(f"_Generated on {now}_\n\n")
@@ -134,9 +137,9 @@ def main():
             f"- Total availability: {total_availability:.1f} FTE\n\n"
         )
         f.write("## Triage Meeting Notes\n\n")
-        f.write("_To be captured in Phase 2_\n\n")
+        f.write(triage_notes + "\n\n")
         f.write("## Sprint Commitment & Goals\n\n")
-        f.write("_To be captured in Phase 2_\n")
+        f.write(commitment + "\n")
 
 
 if __name__ == "__main__":

--- a/sprint_planning.py
+++ b/sprint_planning.py
@@ -1,0 +1,84 @@
+"""Sprint planning utilities including triage meeting simulation."""
+from typing import List, Tuple
+
+from ticket_system import Ticket
+from team_members import TeamMember
+
+
+PRIORITY_ORDER = {
+    "Critical": 1,
+    "High": 2,
+    "Medium": 3,
+    "Low": 4,
+}
+
+
+def _prioritize_tickets(tickets: List[Ticket]) -> List[Ticket]:
+    """Return tickets sorted by priority and dependencies."""
+    # Simple topological sort respecting dependencies then priority
+    ticket_map = {t.ticket_id: t for t in tickets}
+    visited = set()
+    ordered: List[Ticket] = []
+
+    def visit(ticket: Ticket):
+        if ticket.ticket_id in visited:
+            return
+        for dep in ticket.dependencies:
+            if dep in ticket_map:
+                visit(ticket_map[dep])
+        visited.add(ticket.ticket_id)
+        ordered.append(ticket)
+
+    for t in sorted(tickets, key=lambda x: PRIORITY_ORDER.get(x.priority, 5)):
+        visit(t)
+
+    # Remove duplicates while preserving order
+    seen = set()
+    final = []
+    for t in ordered:
+        if t.ticket_id not in seen:
+            final.append(t)
+            seen.add(t.ticket_id)
+    return final
+
+
+def simulate_triage_meeting(tickets: List[Ticket], team: List[TeamMember]) -> Tuple[str, str]:
+    """Simulate a triage meeting and return markdown sections."""
+    ordered = _prioritize_tickets(tickets)
+
+    capacity = int(sum(m.availability for m in team) * 8)  # simple velocity model
+    velocity = 0
+    commitment: List[Ticket] = []
+
+    for t in ordered:
+        effort = t.estimated_effort or 1
+        if velocity + effort > capacity:
+            continue
+        if any(m.can_handle_ticket(t) for m in team):
+            commitment.append(t)
+            velocity += effort
+
+    dep_pairs = [f"{t.ticket_id}->{dep}" for t in ordered for dep in t.dependencies]
+
+    notes_lines = [
+        f"- Reviewed {len(tickets)} tickets and prioritized Critical and High items first.",
+        "- Matched work to available team skills and workloads.",
+    ]
+    if dep_pairs:
+        notes_lines.append(
+            "- Sequenced dependent work: " + ", ".join(dep_pairs)
+        )
+    notes_lines.extend([
+        "- Flagged high-effort items for risk mitigation.",
+        f"- Team capacity for this sprint is {capacity} story points; committed {velocity} points of work.",
+    ])
+
+    commit_lines = ["| Ticket ID | Priority | Est Effort |", "|---|---|---|"]
+    for t in commitment:
+        commit_lines.append(
+            f"| {t.ticket_id} | {t.priority} | {t.estimated_effort or 1} |"
+        )
+    commit_lines.append("")
+    commit_lines.append(f"Estimated velocity: {velocity} pts")
+
+    return "\n".join(notes_lines), "\n".join(commit_lines)

--- a/tests/test_pre_sprint_analysis.py
+++ b/tests/test_pre_sprint_analysis.py
@@ -14,9 +14,15 @@ def test_pre_sprint_analysis_output(tmp_path):
     assert "## Ticket Backlog" in content
     assert "## Team Capacity & Skill Matrix" in content
 
+    start = content.index("## Ticket Backlog")
+    end = content.index("## Team Capacity", start)
+    backlog_section = content[start:end]
     ticket_lines = [
         line
-        for line in content.splitlines()
+        for line in backlog_section.splitlines()
         if line.startswith("| SNW-") or line.startswith("| JIRA-")
     ]
     assert len(ticket_lines) == 5
+
+    assert "_To be captured in Phase 2" not in content
+    assert "Estimated velocity" in content

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,0 +1,16 @@
+from team_members import TeamMember
+from ticket_system import Ticket
+from sprint_planning import simulate_triage_meeting
+
+
+def test_triage_prioritization_and_commitment():
+    team = [TeamMember(name="dev", role="Developer", skill_level=8, specialties=["Email"])]
+    t1 = Ticket(ticket_id="SNW-1", source="ServiceNow", priority="Critical", category="Email", description="A", estimated_effort=3)
+    t2 = Ticket(ticket_id="SNW-2", source="ServiceNow", priority="Low", category="Email", description="B", estimated_effort=2, dependencies=["SNW-1"])
+
+    notes, commit = simulate_triage_meeting([t2, t1], team)
+
+    commit_lines = [l for l in commit.splitlines() if l.startswith("|")]
+    assert commit_lines[2].split("|")[1].strip() == "SNW-1"
+    assert "Estimated velocity" in commit
+    assert "capacity" in notes.lower()


### PR DESCRIPTION
## Summary
- implement `simulate_triage_meeting` for Phase 2 triage process
- integrate triage notes generation into pre‑sprint analysis output
- test triage function and verify notes in generated markdown

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68700194024c8331894c4960e5eed0f2